### PR TITLE
Update installation instructions and CMake files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ext/nanogui"]
 	path = ext/nanogui
-	url = git@github.com:mitsuba-renderer/nanogui.git
+	url = https://github.com/mitsuba-renderer/nanogui.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,24 @@ add_subdirectory(src/network)
 set(NO_GFX OFF CACHE BOOL "Exclude all graphics libraries and the base station")
 
 if (NOT NO_GFX)
+	find_package(OpenGL)
+	if (OPENGL_FOUND)
+		if (NOT EXISTS ext/nanogui/CMakeLists.txt AND NOT NO_GFX)
+			message(FATAL_ERROR
+				"Base station required submodules are missing! Either explicilty set "
+				"NO_GFX=ON to exclude the base station or clone all submodules (run:"
+				" git submodule update --init --recursive)"
+			)
+		endif()
+	elseif(NOT NO_GFX)
+		message(WARNING
+			"No graphics support. Excluding base station and building in onboard mode. To"
+			" disable this warning, explicitly set NO_GFX=ON"
+		)
+	endif()
+endif()
+
+if (NOT NO_GFX AND OPENGL_FOUND)
 	set(NANOGUI_BUILD_EXAMPLES	OFF CACHE BOOL " " FORCE)
 	set(NANOGUI_BUILD_PYTHON	OFF CACHE BOOL " " FORCE)
 	set(NANOGUI_INSTALL			OFF CACHE BOOL " " FORCE)
@@ -23,5 +41,5 @@ if (NOT NO_GFX)
 
 	add_subdirectory(src/basestation)
 else()
-	message("NO_GFX is ON. Base Station is excluded from this build.")
+	message(STATUS "NO_GFX is ON. Base Station is excluded from this build.")
 endif()

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ While you are not locked to a specific toolchain, the process suggested below wi
 * Install a C++ compiler. We typically recommended g++ (`sudo apt install g++`), though Clang should work too.
 * Install a build system tool like [Make](https://www.gnu.org/software/make/) or [Ninja](https://ninja-build.org/). Though Make is fairly ubiquitous, Ninja is newer, faster, and designed for automated generation by tools like CMake. We recommend Ninja, and these instructions always show Ninja. However, wherever `ninja` appears, it can be replaced with `make` to accomplish the same task (except for installation). Installation: `sudo apt install ninja-build` or `sudo apt install make`.
 #### Required Dependencies
-<p id="build"> </p>
-
 * Install Boost libraries: `sudo apt install libboost-dev libboost-program-options-dev`
   * You need at least Boost 1.71. Older versions will not work.
 * Install Protocol Buffers: `sudo apt install protobuf-compiler`
+
+<p id="build-ubuntu"></p>
 
 #### Building
 * Generate the build files with CMake by running this command in the repository root: `CXX=g++ cmake -S . -B build -GNinja`
@@ -72,13 +72,13 @@ Must have [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12), otherw
 #### Suggested Toolchain
   * Installing git: `brew install git`
   * Installing CMake: `brew install cmake`
-  * Installing a C++ should not be required as Xcode contains one suited for C/C++ files.
-  * Installing a build system tool. `Make or Ninja`. We recommend `Ninja` as it is newer, faster, and designed for automated generation by tools like CMake. These instructions always show Ninja. However, wherever ninja appears, it can be replaced with make to accomplish the same task (except for installation). 
+  * Installing a C++ compiler should not be required as Xcode contains one suited for C/C++ files.
+  * Installing a build system tool. `Make or Ninja`. We recommend `Ninja` as it is newer, faster, and designed for automated generation by tools like CMake. These instructions always show Ninja. However, wherever ninja appears, it can be replaced with make to accomplish the same task. 
     * Installation: `brew install ninja` or `brew install make`.
 #### Required Dependencies
 * Install Protocol Buffers: `brew install protobuf`
 * Install Boost Libraries: `brew install boost`
-* You can follow Ubuntu's <a href="#build">section</a> for instructions on building.
+* Follow [Ubuntu's build instructions](#build-ubuntu).
 ### CMake Variables
 Set variables with CMake on the command line by adding: `-DVARIABLE_NAME=VALUE`
 #### NO_GFX

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ While you are not locked to a specific toolchain, the process suggested below wi
 * Install a C++ compiler. We typically recommended g++ (`sudo apt install g++`), though Clang should work too.
 * Install a build system tool like [Make](https://www.gnu.org/software/make/) or [Ninja](https://ninja-build.org/). Though Make is fairly ubiquitous, Ninja is newer, faster, and designed for automated generation by tools like CMake. We recommend Ninja, and these instructions always show Ninja. However, wherever `ninja` appears, it can be replaced with `make` to accomplish the same task (except for installation). Installation: `sudo apt install ninja-build` or `sudo apt install make`.
 #### Required Dependencies
+<p id="build"> </p>
+
 * Install Boost libraries: `sudo apt install libboost-dev libboost-program-options-dev`
   * You need at least Boost 1.71. Older versions will not work.
 * Install Protocol Buffers: `sudo apt install protobuf-compiler`
-<p id="build"> </p>
 
+#### Building
 * Generate the build files with CMake by running this command in the repository root: `CXX=g++ cmake -S . -B build -GNinja`
   * CMake caches options like `GXX=g++` and `-GNinja` in the build directory. To change a CMake variable definition (ex. change build type to Release), you do not need to supply the other options. In this example, `cmake -B build -DCMAKE_BUILD_TYPE=Release` will work.
   * See the [CMake Variables](#cmake-variables) section for additional options.

--- a/README.md
+++ b/README.md
@@ -2,60 +2,77 @@
 BurtOS encompasses the base station and rover computer applications deployed to operate the Binghamton University Rover Team's Mars rover. This 2.0 version was started in the 2022 competition year and will replace the legacy RoverSystem software. The decision to redevelop the software was reached after evaluating weaknesses and scalability issues in the legacy software. We intend BurtOS 2.0 to be highly modular to rapidly adapt to rover hardware changes.
 
 ## Contents
-- [BurtOS 2 Applications](#burtos-2-applications)
+- [Components](#components)
 - [Building](#building)
-  - [C++ Compilers](#c-compiler)
   - [Ubuntu](#ubuntu)
   - [Windows](#windows)
-  - [MacOS](#macos)
-  - [CMake Usage](#cmake-usage)
+  - [macOS](#macos)
+  - [CMake Variables](#cmake-variables)
 
-## BurtOS 2 Applications
+## Components
 BurtOS 2 is a new project and thus this section reflects our design goals.
 
 ### Base Station
+**Target name:** basestation<br>
 The base station is used to drive the rover and monitor onboard sensors. The base station GUI will offer modular windows for monitoring the rover. The base station uses GLFW and NanoGUI for graphics rendering and input processing.
 
-### Subsystems Computer
-The subsystems computer program runs on an onboard Raspberry Pi. It receives commands from the base station and controls hardware on the rover.
+### Subsystem
+**Target name:** subsystem<br>
+The subsystem program runs on an onboard Raspberry Pi. It receives commands from the base station and controls hardware on the rover.
 
-### Video/Perception Computer
-The video/perception computer program streams video from rover cameras to the base station.
+### Video/Perception
+Not updated for BurtOS-2. The video/perception computer program streams video from rover cameras to the base station.
 
 ## Building
-All libraries and applications in BurtOS 2.0 are designed to allow cross-platform development. However, we primarily support Ubuntu-based operating systems for deployment. The rover computer apps may use libraries only present on Raspberry Pi OS, but we will provide options to build without those features for testing purposes.
+All libraries and applications in BurtOS 2.0 allow cross-platform development. However, we primarily support Ubuntu-based operating systems for deployment. The subsystem apps use libraries only present on Linux and/or Raspberry Pi OS, but these features are automatically disabled when unavailable on the system.
 
 BurtOS 2 uses CMake, which generates makefiles for many build systems, compilers, and IDEs. Be sure to use CMake 3.16 or newer. Check whether CMake is installed and meets the version requirement with this terminal command: `cmake --version`.
 
-To start, make sure you have a working C++ compiler. Then, clone this repository to your computer. BurtOS 2 uses git submodules which must be initialzed. In the clone command, append the option `--recurse-submodules` or clone normally and execute `git submodule update --init --recursive`. After cloning, follow the build instructions for your platform.
-
-### C++ Compiler
-All of the software uses C++, so the first step is installing a C++ compiler.
-
-On Ubuntu, you can install g++ or clang++ using the apt package manager (g++ is standalone, clang++ comes with clang). These compilers are also available for MacOS.
-
-On Windows, you can use Microsoft's Visual C++ Compiler that's included in Visual Studio 2019 Community (not to be confused with Visual Studio Code). Additionally, Minimalistic GNU For Windows (MinGW) works on the example code, but may cause problems with potential future dependencies. Cygwin compiles everything, but produces errors in the linking stage.
+If you intend on building the base station, run `git submodule update --init --recursive` from the repository root. Follow the build instructions for your platform.
 
 ### Ubuntu
-If CMake is not found, install it with: `sudo apt install cmake`.
-
-Open a terminal in the repository root. Run the command: `CXX=g++ cmake -S . -B build` This command generates Makefiles for g++ in the "build" directory. You can build the project by running `make` in the build directory. The executables will output to `build/bin`. Tip: Use the option `-C build` for ninja/make to run from the repository root.
-
-You can also specify `-Gninja` to use ninja-build instead of the traditional make. Ninja is a replacement for make and runs much faster.
+While you are not locked to a specific toolchain, the process suggested below will get you started. The dependencies, however, are not optional.
+#### Suggested Toolchain
+* Before starting, update your local package information by running `sudo apt update`. You may want to upgrade your packages as well (`sudo apt upgrade`).
+* Install git: `sudo apt install git`
+  * Clone this repository and enter the BurtOS-2 directory. Run `git submodule update --init --recursive` (unless you do not need to build the base station)
+* Install CMake with: `sudo apt install cmake`.
+* Install a C++ compiler. We typically recommended g++ (`sudo apt install g++`), though Clang should work too.
+* Install a build system tool like [Make](https://www.gnu.org/software/make/) or [Ninja](https://ninja-build.org/). Though Make is fairly ubiquitous, Ninja is newer, faster, and designed for automated generation by tools like CMake. We recommend Ninja, and these instructions always show Ninja. However, wherever `ninja` appears, it can be replaced with `make` to accomplish the same task (except for installation). Installation: `sudo apt install ninja-build` or `sudo apt install make`.
+#### Required Dependencies
+* Install Boost libraries: `sudo apt install libboost-dev libboost-program-options-dev`
+  * You need at least Boost 1.71. Older versions will not work.
+* Install Protocol Buffers: `sudo apt install protobuf-compiler`
+* Generate the build files with CMake by running this command in the repository root: `CXX=g++ cmake -S . -B build -GNinja`
+  * CMake caches options like `GXX=g++` and `-GNinja` in the build directory. To change a CMake variable definition (ex. change build type to Release), you do not need to supply the other options. In this example, `cmake -B build -DCMAKE_BUILD_TYPE=Release` will work.
+  * See the [CMake Variables](#cmake-variables) section for additional options.
+* Build the project: `ninja -C build`. The executables are placed in `build/bin/`.
+  * The `-C [directory]` option specifies the directory for Ninja/Make to use. The default is the current directory. You could also `cd build` and only run `ninja`.
+  * For all target names, see [Components](#components). This example will build only the base station: `ninja -C build basestation`.
 
 ### Windows
-Read the Ubuntu section for tips and more context on each command.
-First, install the CMake binary from [Kitware](https://cmake.org/download/).
-#### Visual Studio 2019
-Open a terminal in the repository root. Run the command: `cmake -S . -B build -G"Visual Studio 16 2019"`. Then, open the newly created solution file (located at build/BurtOS-2.sln) in Visual Studio 2019. The solution explorer shows the applications and libraries, and their source code is accessible in the "Source Files" folder under the project name. To compile and execute the bae station, right click on "basestation" in the Solution Explorer and select "Set as Startup Project". Then, press the "Local Windows Debugger" with the green play button (located in the toolbar) to compile and run.
+Only two options are supported for building on Windows: [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) and [MSYS2 MinGW](https://www.msys2.org/). If you choose WSL, follow the Ubuntu instructions. See MSYS2 MinGW instructions below.
+#### MSYS2 MinGW
+The [Ubuntu](#ubuntu) section provides more context for each command, so read over that section, too. Both procedures are similar, but with different package managers (pacman vs APT) and different package names.
+* Install git. You can use Git for Windows or install git in MINGW: `pacman -S git`. While both can be installed on the same system, they are not interchangeable since Git for Windows uses CRLF line endings and MINGW git uses LF line endings.
+* Install CMake: `pacman -S mingw-w64-x86_64-cmake`
+* Install Ninja: `pacman -S mingw-w64-x86_64-ninja`
+* Install Boost libraries: `pacman -S mingw-w64-x86_64-boost`
+* Install Protocol Buffers: `pacman -S mingw-w64-x86_64-protobuf`
+* Generate build files: `CXX=g++ cmake -S . -B build -GNinja`
+* Build the project: `ninja -C build`
 
-#### MinGW
-Run this command to generate the makefiles: `cmake -S . -B build -G"MinGW Makefiles"`. The project can be built by running `make` in the build directory.
+### macOS
+Section expansion needed. Installation is likely similar to the Ubuntu instructions but with a macOS package manager (Homebrew?).
 
-### MacOS
-BurtOS 2 is untested on MacOS, although it is likely similar to the Ubuntu instructions but with the Mac version of `apt`.
-
-### CMake Usage
-New source files must be added to the CMakeLists.txt for each target. Note that the selected compiler and build system are cached, so whenever CMake changes (ex. adding source files, changing variables like NO_GFX), you do not need to specify `CXX=...` or `-G"..."`.
-
-To avoid building the base staion and graphics dependencies on Raspberry Pi, run CMake with `-D NO_GFX=ON`.
+### CMake Variables
+Set variables with CMake on the command line by adding: `-DVARIABLE_NAME=VALUE`
+#### NO_GFX
+**Default:** OFF<br>
+**Description:** If set to `ON`, the base station and dependencies will not be built. Use when compiling on Raspberry Pi or when graphics support is not needed. If not specified, CMake will try to detect whether the system supports graphics. If OpenGL is missing, NO_GFX is set to ON and a warning is produced.
+#### BUILD_NETWORK_APPS
+**Default:** OFF<br>
+**Description:** If set to `ON`, the network library example applications will be built. This includes `chat` and `rtt`.
+#### (Future) ONBOARD_CAN_BUS
+**Default:** automatic detection<br>
+**Description:** If set to `ON`, the subsystem program will be compiled with Linux-only CAN bus libraries. Otherwise, the program is compiled in offline mode and calling CAN bus functions has no effect.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ While you are not locked to a specific toolchain, the process suggested below wi
 * Install Boost libraries: `sudo apt install libboost-dev libboost-program-options-dev`
   * You need at least Boost 1.71. Older versions will not work.
 * Install Protocol Buffers: `sudo apt install protobuf-compiler`
+<p id="build"> </p>
+
 * Generate the build files with CMake by running this command in the repository root: `CXX=g++ cmake -S . -B build -GNinja`
   * CMake caches options like `GXX=g++` and `-GNinja` in the build directory. To change a CMake variable definition (ex. change build type to Release), you do not need to supply the other options. In this example, `cmake -B build -DCMAKE_BUILD_TYPE=Release` will work.
   * See the [CMake Variables](#cmake-variables) section for additional options.
@@ -63,8 +65,18 @@ The [Ubuntu](#ubuntu) section provides more context for each command, so read ov
 * Build the project: `ninja -C build`
 
 ### macOS
-Section expansion needed. Installation is likely similar to the Ubuntu instructions but with a macOS package manager (Homebrew?).
-
+Must have [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12), otherwise a compile error will occur as some of Xcode's command line tools are necessary.
+* When installing Xcode your MacOS must be fully updated.
+#### Suggested Toolchain
+  * Installing git: `brew install git`
+  * Installing CMake: `brew install cmake`
+  * Installing a C++ should not be required as Xcode contains one suited for C/C++ files.
+  * Installing a build system tool. `Make or Ninja`. We recommend `Ninja` as it is newer, faster, and designed for automated generation by tools like CMake. These instructions always show Ninja. However, wherever ninja appears, it can be replaced with make to accomplish the same task (except for installation). 
+    * Installation: `brew install ninja` or `brew install make`.
+#### Required Dependencies
+* Install Protocol Buffers: `brew install protobuf`
+* Install Boost Libraries: `brew install boost`
+* You can follow Ubuntu's <a href="#build">section</a> for instructions on building.
 ### CMake Variables
 Set variables with CMake on the command line by adding: `-DVARIABLE_NAME=VALUE`
 #### NO_GFX


### PR DESCRIPTION
The root README.md files has been updated to reflect how users should build the project on Ubuntu, Windows, and Mac. Additionally, CMake now produces an error to remind users who forgot to initialize git submodules.

Closes #13