### PR TITLE
Fix incorrectly thrown CMake error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(NO_GFX OFF CACHE BOOL "Exclude all graphics libraries and the base station")
 if (NOT NO_GFX)
 	find_package(OpenGL)
 	if (OPENGL_FOUND)
-		if (NOT EXISTS ext/nanogui/CMakeLists.txt AND NOT NO_GFX)
+		if (NOT EXISTS ${PROJECT_SOURCE_DIR}/ext/nanogui/CMakeLists.txt AND NOT NO_GFX)
 			message(FATAL_ERROR
 				"Base station required submodules are missing! Either explicilty set "
 				"NO_GFX=ON to exclude the base station or clone all submodules (run:"


### PR DESCRIPTION
Hotfix for a new discovery with CMake. Sometimes verifying that `ext/nanogui/CMakeLists.txt` exists fails because CMake must use a different directory for relative pathing. This tends to happen if a CMakeLists.txt file is modify and the build tool automatically regenerates make files. Adding `${PROJECT_SOURCE_DIR}` ensures the path is relative to the repo root.