### PR TITLE
Fix search path error for TurboJPEG

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Set variables with CMake on the command line by adding: `-DVARIABLE_NAME=VALUE`
 #### BUILD_NETWORK_APPS
 **Default:** OFF<br>
 **Description:** If set to `ON`, the network library example applications will be built. This includes `chat` and `rtt`.
+#### PKG_TURBOJPEG_PATH
+**Default:** /opt/libjpeg-turbo/lib64/pkgconfig<br>
+**Description:** Search path for pkg-config to find TurboJPEG for the video computer. Only applicable on Linux-based systems.
 #### (Future) ONBOARD_CAN_BUS
 **Default:** automatic detection<br>
 **Description:** If set to `ON`, the subsystem program will be compiled with Linux-only CAN bus libraries. Otherwise, the program is compiled in offline mode and calling CAN bus functions has no effect.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Set variables with CMake on the command line by adding: `-DVARIABLE_NAME=VALUE`
 **Description:** If set to `ON`, the network library example applications will be built. This includes `chat` and `rtt`.
 #### PKG_TURBOJPEG_PATH
 **Default:** /opt/libjpeg-turbo/lib64/pkgconfig<br>
-**Description:** Search path for pkg-config to find TurboJPEG for the video computer. Only applicable on Linux-based systems.
+**Description:** Search path for pkg-config to find TurboJPEG for the video computer. Only applicable if TurboJPEG was installed manually. Path is not referenced for packages installed with APT.
 #### (Future) ONBOARD_CAN_BUS
 **Default:** automatic detection<br>
 **Description:** If set to `ON`, the subsystem program will be compiled with Linux-only CAN bus libraries. Otherwise, the program is compiled in offline mode and calling CAN bus functions has no effect.

--- a/src/roverlua/CMakeLists.txt
+++ b/src/roverlua/CMakeLists.txt
@@ -3,3 +3,4 @@ add_library(roverlua rover_lua.hpp rover_lua.cpp interactive_lua.hpp interactive
 target_link_libraries(roverlua PUBLIC ${LUA_LIBRARIES})
 target_include_directories(roverlua PUBLIC ${LUA_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(roverlua PROPERTIES LINKER_LANGUAGE CXX)
+target_compile_features(roverlua PRIVATE cxx_std_17)

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -17,6 +17,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 			add_executable(video camera.hpp camera.cpp session.hpp session.cpp main.cpp)
 			target_link_libraries(video roversystem_utils PkgConfig::PKG_LIBJPEG_TURBO network rover_system_messages)
 			target_include_directories(video PUBLIC rover_system_messages)
+			target_compile_features(video PRIVATE cxx_std_17)
 			set(VIDEO_BUILT ON)
 
 		endif()

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 
 	set(PKG_TURBOJPEG_PATH "/opt/libjpeg-turbo/lib64/pkgconfig" CACHE STRING "Search path for libjpeg-turbo pkg-config files")
-	set(ENV{PKG_CONFIG_PATH} PKG_TURBOJPEG_PATH)
+	set(ENV{PKG_CONFIG_PATH} ${PKG_TURBOJPEG_PATH})
 
 	find_package(PkgConfig)
 	if (NOT PKG_CONFIG_FOUND)

--- a/src/video/session.cpp
+++ b/src/video/session.cpp
@@ -219,7 +219,7 @@ void Session::send_frames() {
                     continue;
                 }
             }
-            std::size_t out_frame_size = frame_size;
+            unsigned long out_frame_size = frame_size;
             // Decode the frame and encode it again to set our desired quality.
             static uint8_t raw_buffer[CAMERA_WIDTH * CAMERA_HEIGHT * 3];
             // Decompress into a raw frame.


### PR DESCRIPTION
The value of `ENV{PKG_CONFIG_PATH}` was not correctly copied from `PKG_TURBOJPEG_PATH` before searching for the package. This quick fix fixes that problem so the default path is used.