### PR TITLE
Add new simple, logical layouts

### DIFF
--- a/src/basestation/CMakeLists.txt
+++ b/src/basestation/CMakeLists.txt
@@ -18,10 +18,12 @@ set(MODULE_SRC
 set(WIDGET_HDR
 	widgets/textarea.hpp
 	widgets/functionbox.hpp
+	widgets/layouts/simple_row.hpp
 )
 set(WIDGET_SRC
 	widgets/textarea.cpp
 	widgets/functionbox.cpp
+	widgets/layouts/simple_row.cpp
 )
 
 add_executable(basestation

--- a/src/basestation/CMakeLists.txt
+++ b/src/basestation/CMakeLists.txt
@@ -20,12 +20,14 @@ set(WIDGET_HDR
 	widgets/textarea.hpp
 	widgets/functionbox.hpp
 	widgets/layouts/simple_row.hpp
+	widgets/layouts/simple_column.hpp
 )
 set(WIDGET_SRC
 	widgets/window.cpp
 	widgets/textarea.cpp
 	widgets/functionbox.cpp
 	widgets/layouts/simple_row.cpp
+	widgets/layouts/simple_column.cpp
 )
 
 add_executable(basestation

--- a/src/basestation/modules/console.cpp
+++ b/src/basestation/modules/console.cpp
@@ -4,6 +4,8 @@
 #include <nanogui/layout.h>
 #include <nanogui/screen.h>
 
+#include <widgets/layouts/simple_row.hpp>
+
 #include <basestation.hpp>
 
 /*
@@ -94,7 +96,8 @@ Console::Console(nanogui::Screen* screen) :
 	console_out->set_font("mono");
 
 	entry_bar = new Widget(this);
-	entry_bar->set_layout(new nanogui::BoxLayout(nanogui::Orientation::Horizontal, nanogui::Alignment::Maximum, layout_margin, layout_spacing));
+	//entry_bar->set_layout(new nanogui::BoxLayout(nanogui::Orientation::Horizontal, nanogui::Alignment::Maximum, layout_margin, layout_spacing));
+	entry_bar->set_layout(new gui::SimpleRowLayout());
 
 	entry = new FunctionBox(entry_bar, "");
 	entry->set_placeholder("");
@@ -146,13 +149,15 @@ Console::Console(nanogui::Screen* screen) :
 	});
 
 	submit = new nanogui::Button(entry_bar, "Run");
+	submit->set_fixed_size(submit->preferred_size(screen->nvg_context()));
 	submit->set_callback([this] {
 		entry->action(FunctionBox::Action::SUBMIT);
 	});
 
-	perform_layout(screen->nvg_context());
+	//perform_layout(screen->nvg_context());
 
-	compute_size();
+	//compute_size();
+	m_parent->perform_layout(screen->nvg_context());
 
 	save_instance(*this);
 	set_write_line_callback([this] (const char* str) {

--- a/src/basestation/modules/console.hpp
+++ b/src/basestation/modules/console.hpp
@@ -32,8 +32,6 @@ protected:
 	std::string uncommitted_entry;
 	std::thread lua_runtime;
 
-	void compute_size();
-
 	inline static std::vector<std::function<void(Console&)>> global_setup;
 	static const struct luaL_Reg term_lib[];
 	static int luaopen_term(lua_State*);
@@ -43,6 +41,7 @@ public:
 	~Console();
 
 	virtual void draw(NVGcontext* ctx);
+	virtual nanogui::Vector2i preferred_size(NVGcontext*) const;
 	
 	// Add a function to run when creating any new Console
 	// Intended for initializing Lua functions and variables 

--- a/src/basestation/modules/drive_stats.hpp
+++ b/src/basestation/modules/drive_stats.hpp
@@ -12,6 +12,8 @@ class DriveStats : public gui::Window {
 	public:
 		DriveStats(nanogui::Screen* screen, nanogui::Vector2i size = 0);
 
+		virtual void perform_layout(NVGcontext*) override;
+
 	private:
 		constexpr static int box_width = 80;
 		constexpr static int min_bar_size = 70;
@@ -25,8 +27,6 @@ class DriveStats : public gui::Window {
 
 		event::Handler drive_mode_update;
 		event::Handler speeds_update;
-
-		void compute_size();
 
 		void update_speed_displays(float l, float r);
 

--- a/src/basestation/widgets/layouts/simple_column.cpp
+++ b/src/basestation/widgets/layouts/simple_column.cpp
@@ -1,0 +1,131 @@
+#include <widgets/layouts/simple_column.hpp>
+
+#include <nanogui/nanogui.h>
+
+gui::SimpleColumnLayout::SimpleColumnLayout(int horizontal_margin, int vertical_margin, int spacing, HorizontalAnchor anchor) :
+	m_horizontal_margin(horizontal_margin),
+	m_vertical_margin(vertical_margin),
+	m_spacing(spacing),
+	m_anchor(anchor) {}
+
+nanogui::Vector2i gui::SimpleColumnLayout::preferred_size(NVGcontext* ctx, const nanogui::Widget* container_widget) const {
+	int width = 0;
+	int height = m_vertical_margin * 2;
+	if (dynamic_cast<const nanogui::Window*>(container_widget)) {
+		height += container_widget->theme()->m_window_header_height;
+	}
+	int visible_widgets = 0;
+
+	for (nanogui::Widget* w : container_widget->children()) {
+		if (!w->visible())
+			continue;
+		++visible_widgets;
+		nanogui::Vector2i ps = w->preferred_size(ctx);
+		width = std::max(width, (w->fixed_width() > 0) ? w->fixed_width() : ps.x());
+
+		height += w->fixed_height() > 0 ? w->fixed_height() : ps.y();
+
+	}
+	width += m_horizontal_margin * 2;
+	height += std::max((visible_widgets - 1) * m_spacing, 0);
+
+	return nanogui::Vector2i(width, height);
+}
+
+void gui::SimpleColumnLayout::perform_layout(NVGcontext* ctx, nanogui::Widget* container_widget) const {
+	// The widget is the container: Check if it has a fixed size. If not, use its set size
+	nanogui::Vector2i c_fixed_size = container_widget->fixed_size();
+	nanogui::Vector2i container_size(
+		c_fixed_size.x() ? c_fixed_size.x() : container_widget->width(),
+		c_fixed_size.y() ? c_fixed_size.y() : container_widget->height()
+	);
+
+
+	// If this container is a window, we must shift widgets down to avoid writing over the header
+	// Fixing this in layouts seems like a hack, but it is how the nanogui layouts do it...
+	int y_offset = m_vertical_margin;
+	if (dynamic_cast<nanogui::Window*>(container_widget)) {
+		y_offset += container_widget->theme()->m_window_header_height;
+	}
+
+	int width = 0;
+	// All usable space: container size less the top offset (y_offset), the bottom margin (not included in y_offset), and spacing
+	int spare_height = container_size.y() - y_offset - m_vertical_margin;
+	int visible_children = 0;
+	int unsized_widgets = 0;
+
+	// First pass: figure out the spare height (total size - fixed-size widgets) and the desired container width
+	for (nanogui::Widget* w : container_widget->children()) {
+		if (!w->visible())
+			continue;
+		++visible_children;
+		
+		if (w->fixed_height() > 0)
+			spare_height -= w->fixed_height();
+		else
+			++unsized_widgets;
+
+		width = std::max(width, w->fixed_width() ? w->fixed_width() : w->preferred_size(ctx).x());
+	}
+	spare_height -= m_spacing * (visible_children - 1);
+	spare_height = std::max(spare_height, 0);
+
+	// Limit the full width to between the container margins
+	width = std::min(width, container_size.x() - m_horizontal_margin * 2);
+
+	// Second pass: begin placement
+	for (nanogui::Widget* w : container_widget->children()) {
+		if (!w->visible())
+			continue;
+		
+		nanogui::Vector2i preferred_sz = w->preferred_size(ctx);
+		nanogui::Vector2i new_pos(m_horizontal_margin, y_offset);
+
+		if (w->fixed_height() > 0) {
+			// If the widget has a fixed height, use that height
+			w->set_height(w->fixed_height());
+
+			y_offset += w->fixed_height();
+		} else {
+			// Otherwise, try to ensure each gets its preferred height, but do not exceed the spare height
+			// In some conditions, some unsized widgets may not fit in the layout
+			int use_height = std::max(std::min(preferred_sz.y(), spare_height), spare_height / unsized_widgets--);
+
+			spare_height -= use_height;
+
+			w->set_height(use_height);
+			y_offset += use_height;
+		}
+		y_offset += m_spacing;
+		
+		if (m_anchor == HorizontalAnchor::STRETCH) {
+			w->set_width(container_size.x() - m_horizontal_margin * 2);
+		} else if (w->fixed_width() > 0) {
+			w->set_width(std::min(w->fixed_width(), width));
+		} else {
+			w->set_width(std::min(preferred_sz.x(), width));
+		}
+
+		int x_pos = 0;
+		switch (m_anchor) {
+			case HorizontalAnchor::CENTER:
+				x_pos = (width - w->width()) / 2;
+				break;
+			case HorizontalAnchor::LEFT:
+				x_pos = 0;
+				break;
+			case HorizontalAnchor::RIGHT:
+				x_pos = width - w->width();
+				break;
+			case HorizontalAnchor::STRETCH:
+				x_pos = 0;
+				break;
+		}
+		new_pos.x() += x_pos;
+		w->set_position(new_pos);
+		w->perform_layout(ctx);
+
+	}
+	
+	
+}

--- a/src/basestation/widgets/layouts/simple_column.hpp
+++ b/src/basestation/widgets/layouts/simple_column.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <nanogui/layout.h>
+
+namespace gui {
+
+/*
+	The simple column layout divides space between all added widgets
+	Widgets with a fixed size still assume their fixed size
+	This is slightly more accurate than the simple row layout so it can work as a "top-level" layout
+*/
+class SimpleColumnLayout : public nanogui::Layout {
+	public:
+		enum class HorizontalAnchor {
+			CENTER,
+			LEFT,
+			RIGHT,
+			STRETCH
+		};
+
+		// Margin: space around the container
+		// Spacing: space between contents
+		// Anchor: how to position widgets that are thinner than the container width
+		SimpleColumnLayout(int h_margin = 6, int v_margin = 6, int spacing = 6, HorizontalAnchor anchor = HorizontalAnchor::CENTER);
+	
+		virtual nanogui::Vector2i preferred_size(NVGcontext* ctx, const nanogui::Widget* widget) const override;
+		virtual void perform_layout(NVGcontext* ctx, nanogui::Widget* widget) const override;
+
+		inline int horizontal_margin() const { return m_horizontal_margin; }
+		inline int vertical_margin() const { return m_vertical_margin; }
+		inline int spacing() const { return m_spacing; }
+		inline HorizontalAnchor anchor() const { return m_anchor; }
+		inline void set_horizontal_margin(int px) { m_horizontal_margin = px; }
+		inline void set_vertical_margin(int px) { m_vertical_margin = px; }
+		inline void set_spacing(int px) { m_spacing = px; }
+		inline void set_anchor(HorizontalAnchor anchor) { m_anchor = anchor; }
+
+	protected:
+		int m_horizontal_margin;
+		int m_vertical_margin;
+		int m_spacing;
+		HorizontalAnchor m_anchor;
+
+};
+
+}

--- a/src/basestation/widgets/layouts/simple_row.cpp
+++ b/src/basestation/widgets/layouts/simple_row.cpp
@@ -1,0 +1,81 @@
+#include <widgets/layouts/simple_row.hpp>
+
+#include <nanogui/nanogui.h>
+
+gui::SimpleRowLayout::SimpleRowLayout(int margin, int spacing) :
+	m_margin(margin),
+	m_spacing(spacing) {}
+
+nanogui::Vector2i gui::SimpleRowLayout::preferred_size(NVGcontext* ctx, const nanogui::Widget* container_widget) const {
+	int height = 0;
+	int width = m_margin * 2 + m_spacing * (container_widget->children().size());
+	for (nanogui::Widget* w : container_widget->children()) {
+		
+		nanogui::Vector2i ps = w->preferred_size(ctx);
+		height = std::max(height, (w->fixed_height() > 0) ? w->fixed_height() : ps.y());
+
+		width += w->fixed_width() > 0 ? w->fixed_width() : ps.x();
+
+	}
+	return nanogui::Vector2i(width, height);
+}
+
+void gui::SimpleRowLayout::perform_layout(NVGcontext* ctx, nanogui::Widget* container_widget) const {
+	// The widget is the container: Check if it has a fixed size. If not, use its set size
+	nanogui::Vector2i c_fixed_size = container_widget->fixed_size();
+	nanogui::Vector2i container_size(
+		c_fixed_size.x() ? c_fixed_size.x() : container_widget->width(),
+		c_fixed_size.y() ? c_fixed_size.y() : container_widget->height()
+	);
+
+	int spare_width = container_size.x() - 2 * m_margin - m_spacing * (container_widget->children().size() - 1);
+	int unsized_widgets = 0;
+
+	// First pass: figure out the spare width (total size - fixed-size widgets)
+	for (nanogui::Widget* w : container_widget->children()) {
+		if (!w->visible())
+			continue;
+		
+		if (w->fixed_width() > 0)
+			spare_width -= w->fixed_width();
+		else
+			++unsized_widgets;
+
+	}
+
+	int offset = m_margin;
+
+	// Second pass: begin placement
+	for (nanogui::Widget* w : container_widget->children()) {
+		if (!w->visible())
+			continue;
+		
+		nanogui::Vector2i preferred_sz = w->preferred_size(ctx);
+
+		w->set_position(nanogui::Vector2i(offset, 0));
+		
+		if (w->fixed_width() > 0) {
+			// If the widget has a fixed width, use that width
+			w->set_width(w->fixed_width());
+
+			offset += w->fixed_width();
+		} else {
+			// Otherwise, ensure it has at least its preferred width
+			int use_width = std::max(preferred_sz.x(), spare_width / unsized_widgets--);
+
+			spare_width -= use_width;
+
+			w->set_width(use_width);
+			offset += use_width;
+		}
+		offset += m_spacing;
+							
+		if (w->fixed_height() > 0) {
+			w->set_height(w->fixed_height());
+		} else {
+			w->set_height(preferred_sz.y());
+		}
+	}
+	
+	
+}

--- a/src/basestation/widgets/layouts/simple_row.cpp
+++ b/src/basestation/widgets/layouts/simple_row.cpp
@@ -9,8 +9,12 @@ gui::SimpleRowLayout::SimpleRowLayout(int margin, int spacing, VerticalAnchor an
 
 nanogui::Vector2i gui::SimpleRowLayout::preferred_size(NVGcontext* ctx, const nanogui::Widget* container_widget) const {
 	int height = 0;
-	int width = m_margin * 2 + m_spacing * (container_widget->children().size());
+	int width = m_margin * 2;
+	int visible_children = 0;
 	for (nanogui::Widget* w : container_widget->children()) {
+		if (!w->visible())
+			continue;
+		++visible_children;
 		
 		nanogui::Vector2i ps = w->preferred_size(ctx);
 		height = std::max(height, (w->fixed_height() > 0) ? w->fixed_height() : ps.y());
@@ -18,6 +22,7 @@ nanogui::Vector2i gui::SimpleRowLayout::preferred_size(NVGcontext* ctx, const na
 		width += w->fixed_width() > 0 ? w->fixed_width() : ps.x();
 
 	}
+	width += std::max(0, m_spacing * (visible_children - 1));
 	return nanogui::Vector2i(width, height);
 }
 
@@ -70,7 +75,7 @@ void gui::SimpleRowLayout::perform_layout(NVGcontext* ctx, nanogui::Widget* cont
 			offset += w->fixed_width();
 		} else {
 			// Otherwise, ensure it has at least its preferred width
-			int use_width = std::max(preferred_sz.x(), spare_width / unsized_widgets--);
+			int use_width = std::max(std::min(spare_width, preferred_sz.x()), spare_width / unsized_widgets--);
 
 			spare_width -= use_width;
 

--- a/src/basestation/widgets/layouts/simple_row.hpp
+++ b/src/basestation/widgets/layouts/simple_row.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <nanogui/nanogui.h>
+
+#include <nanogui/layout.h>
+
+namespace gui {
+
+class SimpleRowLayout : public nanogui::Layout {
+	public:
+		//SimpleRowLayout();
+	
+		virtual nanogui::Vector2i preferred_size(NVGcontext* ctx, const nanogui::Widget* widget) const override {
+
+		}
+		virtual void perform_layout(NVGcontext* ctx, nanogui::Widget* widget) const override {
+			// The widget is the container: Check if it has a fixed size. If not, use its set size
+			nanogui::Vector2i w_fixed_size = widget->fixed_size();
+			nanogui::Vector2i container_size(
+				w_fixed_size.x() ? w_fixed_size.x() : widget->width(),
+				w_fixed_size.y() ? w_fixed_size.y() : widget->height()
+			);
+
+			int spare_width = container_size.x();
+			int unsized_widgets = 0;
+
+			// First pass: figure out the spare width (total size - fixed-size widgets)
+			for (nanogui::Widget* w : widget->children()) {
+				if (!w->visible())
+					continue;
+				
+				if (w->fixed_width() > 0)
+					spare_width -= w->fixed_width();
+				else
+					++unsized_widgets;
+
+			}
+
+			// Second pass: begin placement
+			for (nanogui::Widget* w : widget->children()) {
+				
+			}
+			
+			
+		}
+};
+
+}

--- a/src/basestation/widgets/layouts/simple_row.hpp
+++ b/src/basestation/widgets/layouts/simple_row.hpp
@@ -5,19 +5,38 @@
 namespace gui {
 
 /*
-	The simple row layout divdes space between all added widgets
+	The simple row layout divides space between all added widgets
 	Widgets with a fixed size still assume their fixed size
 */
 class SimpleRowLayout : public nanogui::Layout {
 	public:
-		SimpleRowLayout(int margin = 0, int spacing = 6);
+		enum class VerticalAnchor {
+			CENTER,
+			TOP,
+			BOTTOM,
+			STRETCH
+		};
+
+		// Margin: space left and right of the container
+		// Spacing: space between contents
+		// Anchor: how to position widgets that are shorter than the container height
+		SimpleRowLayout(int margin = 0, int spacing = 6, VerticalAnchor anchor = VerticalAnchor::CENTER);
 	
 		virtual nanogui::Vector2i preferred_size(NVGcontext* ctx, const nanogui::Widget* widget) const override;
 		virtual void perform_layout(NVGcontext* ctx, nanogui::Widget* widget) const override;
 
+		inline int margin() const { return m_margin; }
+		inline int spacing() const { return m_spacing; }
+		inline VerticalAnchor anchor() const { return m_anchor; }
+		inline void set_margin(int px) { m_margin = px; }
+		inline void set_spacing(int px) { m_spacing = px; }
+		inline void set_anchor(VerticalAnchor anchor) { m_anchor = anchor; }
+
 	protected:
 		int m_margin;
 		int m_spacing;
+		VerticalAnchor m_anchor;
+
 };
 
 }

--- a/src/basestation/widgets/layouts/simple_row.hpp
+++ b/src/basestation/widgets/layouts/simple_row.hpp
@@ -1,48 +1,23 @@
 #pragma once
 
-#include <nanogui/nanogui.h>
-
 #include <nanogui/layout.h>
 
 namespace gui {
 
+/*
+	The simple row layout divdes space between all added widgets
+	Widgets with a fixed size still assume their fixed size
+*/
 class SimpleRowLayout : public nanogui::Layout {
 	public:
-		//SimpleRowLayout();
+		SimpleRowLayout(int margin = 0, int spacing = 6);
 	
-		virtual nanogui::Vector2i preferred_size(NVGcontext* ctx, const nanogui::Widget* widget) const override {
+		virtual nanogui::Vector2i preferred_size(NVGcontext* ctx, const nanogui::Widget* widget) const override;
+		virtual void perform_layout(NVGcontext* ctx, nanogui::Widget* widget) const override;
 
-		}
-		virtual void perform_layout(NVGcontext* ctx, nanogui::Widget* widget) const override {
-			// The widget is the container: Check if it has a fixed size. If not, use its set size
-			nanogui::Vector2i w_fixed_size = widget->fixed_size();
-			nanogui::Vector2i container_size(
-				w_fixed_size.x() ? w_fixed_size.x() : widget->width(),
-				w_fixed_size.y() ? w_fixed_size.y() : widget->height()
-			);
-
-			int spare_width = container_size.x();
-			int unsized_widgets = 0;
-
-			// First pass: figure out the spare width (total size - fixed-size widgets)
-			for (nanogui::Widget* w : widget->children()) {
-				if (!w->visible())
-					continue;
-				
-				if (w->fixed_width() > 0)
-					spare_width -= w->fixed_width();
-				else
-					++unsized_widgets;
-
-			}
-
-			// Second pass: begin placement
-			for (nanogui::Widget* w : widget->children()) {
-				
-			}
-			
-			
-		}
+	protected:
+		int m_margin;
+		int m_spacing;
 };
 
 }


### PR DESCRIPTION
This does not pertain to a specific issue.

Adds two gui layouts: SimpleRowLayout and SimpleColumn Layout.

Both of them give all fixed-sized widgets their fixed size and divide the remaining space among the rest. This is extremely useful for resizable windows to adjust their layout without much extra effort.