### PR TITLE
#9 Add the video feed window

### DIFF
--- a/src/basestation/CMakeLists.txt
+++ b/src/basestation/CMakeLists.txt
@@ -9,7 +9,7 @@ set(MODULE_HDR
 )
 set(MODULE_SRC
 	modules/console.cpp
-    modules/video_feeed_viewer.cpp
+	modules/video_feed_viewer.cpp
     modules/video_decoder/decoder.cpp
 	modules/input_config/controller_config.cpp
 	modules/input_config/controller_calibration_popup.cpp
@@ -54,7 +54,7 @@ else()
 				)
 
 		target_include_directories(basestation PUBLIC nanogui roverlua network video ${CMAKE_CURRENT_SOURCE_DIR})
-		target_link_libraries(basestation nanogui ${NANOGUI_EXTRA_LIBS} roverlua network video PkgConfig::PKG_LIBJPEG_TURBO)
+		target_link_libraries(basestation nanogui ${NANOGUI_EXTRA_LIBS} roverlua network PkgConfig::PKG_LIBJPEG_TURBO)
 
 		# NanoGUI requires C++17
 		target_compile_features(basestation PUBLIC cxx_std_17)

--- a/src/basestation/CMakeLists.txt
+++ b/src/basestation/CMakeLists.txt
@@ -1,11 +1,16 @@
 set(MODULE_HDR
 	modules/console.hpp
-	modules/input_config/controller_config.hpp
+	modules/console.hpp
+    modules/video_decoder/decoder.hpp
+    modules/input_config/controller_config.hpp
 	modules/input_config/controller_calibration_popup.hpp
 	modules/input_config/controller_binding_popup.hpp
+	modules/video_feed_viewer.hpp
 )
 set(MODULE_SRC
 	modules/console.cpp
+    modules/video_feeed_viewer.cpp
+    modules/video_decoder/decoder.cpp
 	modules/input_config/controller_config.cpp
 	modules/input_config/controller_calibration_popup.cpp
 	modules/input_config/controller_binding_popup.cpp
@@ -20,30 +25,45 @@ set(WIDGET_SRC
 	widgets/functionbox.cpp
 )
 
-add_executable(basestation
-	main.cpp
-	basestation.hpp
-	basestation.cpp
-	basestation_screen.hpp
-	basestation_screen.cpp
-	controls/controller_manager.hpp
-	controls/controller_manager.cpp
-	controls/controller.hpp
-	controls/controller.cpp
-	controls/lua_ctrl_lib.hpp
-	controls/lua_ctrl_lib.cpp
-	${MODULE_HDR}
-	${MODULE_SRC}
-	${WIDGET_HDR}
-	${WIDGET_SRC} 
-)
+find_package(PkgConfig)
+if (NOT PKG_CONFIG_FOUND)
+	message(STATUS "basestation: pkg-config unavailable.")
+else()
+	pkg_search_module(PKG_LIBJPEG_TURBO IMPORTED_TARGET libturbojpeg)
 
-target_include_directories(basestation PUBLIC nanogui roverlua ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(basestation nanogui ${NANOGUI_EXTRA_LIBS} roverlua)
+	if (NOT PKG_LIBJPEG_TURBO_FOUND)
+		message(STATUS "basestation: libjpeg-turbo unavailable.")
+	else()
 
-# NanoGUI requires C++17
-target_compile_features(basestation PUBLIC cxx_std_17)
+		add_executable(basestation
+				main.cpp
+				basestation.hpp
+				basestation.cpp
+				basestation_screen.hpp
+				basestation_screen.cpp
+				controls/controller_manager.hpp
+				controls/controller_manager.cpp
+				controls/controller.hpp
+				controls/controller.cpp
+				controls/lua_ctrl_lib.hpp
+				controls/lua_ctrl_lib.cpp
+				${MODULE_HDR}
+				${MODULE_SRC}
+				${WIDGET_HDR}
+				${WIDGET_SRC}
+				)
 
-if (APPLE)
-	target_link_libraries(basestation "-framework OpenGL")
+		target_include_directories(basestation PUBLIC nanogui roverlua network video ${CMAKE_CURRENT_SOURCE_DIR})
+		target_link_libraries(basestation nanogui ${NANOGUI_EXTRA_LIBS} roverlua network video PkgConfig::PKG_LIBJPEG_TURBO)
+
+		# NanoGUI requires C++17
+		target_compile_features(basestation PUBLIC cxx_std_17)
+
+		if (APPLE)
+			target_link_libraries(basestation "-framework OpenGL")
+		endif()
+
+	endif()
 endif()
+
+

--- a/src/basestation/basestation.cpp
+++ b/src/basestation/basestation.cpp
@@ -2,6 +2,7 @@
 #include <modules/console.hpp>
 #include <controls/lua_ctrl_lib.hpp>
 
+
 #include <stdexcept>
 
 #include <nanogui/opengl.h>

--- a/src/basestation/basestation.cpp
+++ b/src/basestation/basestation.cpp
@@ -8,13 +8,18 @@
 
 Basestation* Basestation::main_instance = nullptr;
 
-Basestation::Basestation() {
+Basestation::Basestation() :
+	video_feed_receiver(main_thread_ctx)
+{
 	if (main_instance != nullptr) {
 		throw std::runtime_error("Basestation::Basestation: duplicate instance not allowed");
 	}
 	main_instance = this;
 
 	controller_mgr.init();
+
+    //TODO: Dynamically get port number (maybe from config file)
+    video_feed_receiver.set_listen_port(22202);
 
 	Console::add_setup_routine([](Console& new_console) {
 		new_console.load_library("ctrl", lua_ctrl_lib::open);
@@ -50,7 +55,8 @@ BasestationScreen* Basestation::get_focused_screen() const {
 void Basestation::mainloop() {
 	while (continue_operating) {
 		glfwPollEvents();
-		
+		main_thread_ctx.poll();
+
 		controller_mgr.update_controls();
 
 		{

--- a/src/basestation/basestation.cpp
+++ b/src/basestation/basestation.cpp
@@ -1,6 +1,7 @@
 #include <basestation.hpp>
 #include <modules/console.hpp>
 #include <controls/lua_ctrl_lib.hpp>
+#include "../video/session.hpp"
 
 
 #include <stdexcept>
@@ -20,7 +21,14 @@ Basestation::Basestation() :
 	controller_mgr.init();
 
     //TODO: Dynamically get port number (maybe from config file)
-    video_feed_receiver.set_listen_port(22202);
+    boost::asio::ip::udp::endpoint vid_address(
+            boost::asio::ip::address_v4::from_string("239.255.123.123"),
+            22202
+    );
+    video_feed_receiver.subscribe(vid_address);
+    for (int i = 0; i < MAX_STREAMS; i++) {
+        video_feed_receiver.open_stream(i);
+    }
 
 	Console::add_setup_routine([](Console& new_console) {
 		new_console.load_library("ctrl", lua_ctrl_lib::open);

--- a/src/basestation/basestation.hpp
+++ b/src/basestation/basestation.hpp
@@ -7,6 +7,7 @@
 #include <rover_lua.hpp>
 #include <basestation_screen.hpp>
 #include <controls/controller_manager.hpp>
+#include "../network/stream.hpp"
 
 /*
 	Container class for the main instance of the base station
@@ -55,8 +56,15 @@ class Basestation {
 			static void open(lua_State*);
 		};
 
+        inline void set_video_callback(std::function<void(int stream, net::Frame& frame)> handler) {
+            video_feed_receiver.on_frame_received(handler);
+        }
+
 	private:
 		ControllerManager controller_mgr;
+		boost::asio::io_context main_thread_ctx;
+		net::StreamReceiver video_feed_receiver;
+
 
 		std::vector<BasestationScreen*> screens;
 

--- a/src/basestation/basestation.hpp
+++ b/src/basestation/basestation.hpp
@@ -8,6 +8,7 @@
 #include <basestation_screen.hpp>
 #include <controls/controller_manager.hpp>
 #include "../network/stream.hpp"
+#include <iostream>
 
 
 /*
@@ -58,6 +59,7 @@ class Basestation {
 		};
 
         inline void set_video_callback(std::function<void(int stream, net::Frame& frame)> handler) {
+            std::cout << "In callback setter" << std::endl;
             video_feed_receiver.on_frame_received(handler);
         }
 

--- a/src/basestation/basestation.hpp
+++ b/src/basestation/basestation.hpp
@@ -9,6 +9,7 @@
 #include <controls/controller_manager.hpp>
 #include "../network/stream.hpp"
 
+
 /*
 	Container class for the main instance of the base station
 */

--- a/src/basestation/basestation_screen.cpp
+++ b/src/basestation/basestation_screen.cpp
@@ -2,6 +2,7 @@
 #include <basestation.hpp>
 
 #include <modules/console.hpp>
+#include <modules/video_feed_viewer.hpp>
 
 ScreenPositioning::ScreenPositioning(const nanogui::Vector2i& size, const nanogui::Vector2i& window_pos, int monitor, bool use_fullscreen) :
 	size(size),
@@ -96,7 +97,12 @@ bool BasestationScreen::keyboard_event(int key, int scancode, int action, int mo
 	} else if (key == GLFW_KEY_N && action == GLFW_PRESS && (mods & GLFW_MOD_CONTROL)) {
 		Basestation::get().add_screen(new BasestationScreen());
 		handled = true;
-	}
+	} else if (key == GLFW_KEY_C) {
+        auto feed_view = new VideoFeedViewer(this);
+        Basestation::get().set_video_callback(VideoFeedViewer::update_frame_STATIC);
+
+        handled = true;
+    }
 
 	return handled;
 }

--- a/src/basestation/basestation_screen.cpp
+++ b/src/basestation/basestation_screen.cpp
@@ -97,10 +97,9 @@ bool BasestationScreen::keyboard_event(int key, int scancode, int action, int mo
 	} else if (key == GLFW_KEY_N && action == GLFW_PRESS && (mods & GLFW_MOD_CONTROL)) {
 		Basestation::get().add_screen(new BasestationScreen());
 		handled = true;
-	} else if (key == GLFW_KEY_C) {
-        auto feed_view = new VideoFeedViewer(this);
+	} else if (key == GLFW_KEY_C && action == GLFW_PRESS) {
+        new VideoFeedViewer(this);
         Basestation::get().set_video_callback(VideoFeedViewer::update_frame_STATIC);
-
         handled = true;
     }
 

--- a/src/basestation/modules/video_decoder/decoder.cpp
+++ b/src/basestation/modules/video_decoder/decoder.cpp
@@ -1,0 +1,27 @@
+
+#include "decoder.hpp"
+
+Decoder::Decoder() {
+    jpeg_decompressor = tjInitDecompress();
+}
+
+Decoder::~Decoder() {
+    tjDestroy(jpeg_decompressor);
+}
+
+void Decoder::decode_frame( net::Frame& frame, uint8_t* out_buffer) {
+    if (!tjDecompress2(
+            jpeg_decompressor,
+            (unsigned char *)frame.data(),
+            (long unsigned int)frame.size(),
+            (unsigned char *)out_buffer,
+            CAMERA_WIDTH,
+            3 * CAMERA_WIDTH,
+            CAMERA_HEIGHT,
+            TJPF_RGB,
+            TJFLAG_NOREALLOC
+            )) {
+        out_buffer = nullptr;
+        throw std::runtime_error("Decoder::frame_decoder: Couldn't decode incoming frame");
+    }
+}

--- a/src/basestation/modules/video_decoder/decoder.cpp
+++ b/src/basestation/modules/video_decoder/decoder.cpp
@@ -10,7 +10,7 @@ Decoder::~Decoder() {
 }
 
 void Decoder::decode_frame( net::Frame& frame, uint8_t* out_buffer) {
-    if (!tjDecompress2(
+    if (tjDecompress2(
             jpeg_decompressor,
             (unsigned char *)frame.data(),
             (long unsigned int)frame.size(),
@@ -22,6 +22,6 @@ void Decoder::decode_frame( net::Frame& frame, uint8_t* out_buffer) {
             TJFLAG_NOREALLOC
             )) {
         out_buffer = nullptr;
-        throw std::runtime_error("Decoder::frame_decoder: Couldn't decode incoming frame");
+        throw std::runtime_error(tjGetErrorStr());
     }
 }

--- a/src/basestation/modules/video_decoder/decoder.cpp
+++ b/src/basestation/modules/video_decoder/decoder.cpp
@@ -12,9 +12,9 @@ Decoder::~Decoder() {
 void Decoder::decode_frame( net::Frame& frame, uint8_t* out_buffer) {
     if (tjDecompress2(
             jpeg_decompressor,
-            (unsigned char *)frame.data(),
+            frame.data(),
             (long unsigned int)frame.size(),
-            (unsigned char *)out_buffer,
+            out_buffer,
             CAMERA_WIDTH,
             3 * CAMERA_WIDTH,
             CAMERA_HEIGHT,

--- a/src/basestation/modules/video_decoder/decoder.hpp
+++ b/src/basestation/modules/video_decoder/decoder.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <turbojpeg.h>
+#include <GL/gl.h>
+#include "../../../network/stream.hpp"
+#include "../../../video/session.hpp"
+
+class Decoder {
+private:
+    tjhandle jpeg_decompressor;
+public:
+    Decoder();
+    ~Decoder();
+    void decode_frame(net::Frame& frame, unsigned char * out_buffer);
+};

--- a/src/basestation/modules/video_feed_viewer.cpp
+++ b/src/basestation/modules/video_feed_viewer.cpp
@@ -7,9 +7,15 @@ VideoFeedViewer::VideoFeedViewer(nanogui::Screen *screen) :
     nanogui::Window(screen, "Rover Feed"),
     decoder()
 {
-    video_widget = new nanogui::ImageView(this);
-    perform_layout(screen->nvg_context());
     vid_feed = this;
+
+    set_position(nanogui::Vector2i(15,15));
+    set_layout(new nanogui::GroupLayout());
+    set_fixed_size(nanogui::Vector2i(864,490));
+
+    video_widget = new nanogui::ImageView(this);
+
+    perform_layout(screen->nvg_context());
 }
 
 void VideoFeedViewer::update_frame_STATIC(int stream, net::Frame& frame){
@@ -28,9 +34,16 @@ void VideoFeedViewer::update_frame(int stream, net::Frame& frame) {
     }
 
     nanogui::Texture* next_frame = new nanogui::Texture(
-            nanogui::Texture::PixelFormat::RGB,
-            nanogui::Texture::ComponentFormat::UInt8,
-            nanogui::Vector2i(CAMERA_WIDTH, CAMERA_HEIGHT));
+        nanogui::Texture::PixelFormat::RGB,
+        nanogui::Texture::ComponentFormat::UInt8,
+        nanogui::Vector2i(1280,730),
+        nanogui::Texture::InterpolationMode::Bilinear,
+        nanogui::Texture::InterpolationMode::Nearest,
+        nanogui::Texture::WrapMode::ClampToEdge,
+        (uint8_t) 1,
+        nanogui::Texture::TextureFlags::ShaderRead,
+        false
+    );
 
     video_widget->set_image(next_frame);
 }

--- a/src/basestation/modules/video_feed_viewer.cpp
+++ b/src/basestation/modules/video_feed_viewer.cpp
@@ -36,7 +36,7 @@ void VideoFeedViewer::update_frame(int stream, net::Frame& frame) {
     nanogui::Texture* next_frame = new nanogui::Texture(
         nanogui::Texture::PixelFormat::RGB,
         nanogui::Texture::ComponentFormat::UInt8,
-        nanogui::Vector2i(1280,730),
+        nanogui::Vector2i(CAMERA_WIDTH,CAMERA_HEIGHT),
         nanogui::Texture::InterpolationMode::Bilinear,
         nanogui::Texture::InterpolationMode::Nearest,
         nanogui::Texture::WrapMode::ClampToEdge,
@@ -45,6 +45,7 @@ void VideoFeedViewer::update_frame(int stream, net::Frame& frame) {
         false
     );
 
+    next_frame->upload((uint8_t *) next_frame_buffer);
     video_widget->set_image(next_frame);
 }
 

--- a/src/basestation/modules/video_feed_viewer.cpp
+++ b/src/basestation/modules/video_feed_viewer.cpp
@@ -1,0 +1,37 @@
+
+#include "video_feed_viewer.hpp"
+
+VideoFeedViewer* vid_feed = nullptr;
+
+VideoFeedViewer::VideoFeedViewer(nanogui::Screen *screen) :
+    nanogui::Window(screen, "Rover Feed"),
+    decoder()
+{
+    video_widget = new nanogui::ImageView(this);
+    perform_layout(screen->nvg_context());
+    vid_feed = this;
+}
+
+void VideoFeedViewer::update_frame_STATIC(int stream, net::Frame& frame){
+    vid_feed->update_frame(stream, frame);
+}
+
+void VideoFeedViewer::update_frame(int stream, net::Frame& frame) {
+    uint8_t next_frame_buffer[CAMERA_HEIGHT*CAMERA_WIDTH*3];
+
+    try {
+        decoder.decode_frame(frame, next_frame_buffer);
+    }
+    catch(std::runtime_error& e) {
+        std::cerr << e.what() << std::endl;
+        return;
+    }
+
+    nanogui::Texture* next_frame = new nanogui::Texture(
+            nanogui::Texture::PixelFormat::RGB,
+            nanogui::Texture::ComponentFormat::UInt8,
+            nanogui::Vector2i(CAMERA_WIDTH, CAMERA_HEIGHT));
+
+    video_widget->set_image(next_frame);
+}
+

--- a/src/basestation/modules/video_feed_viewer.cpp
+++ b/src/basestation/modules/video_feed_viewer.cpp
@@ -11,9 +11,10 @@ VideoFeedViewer::VideoFeedViewer(nanogui::Screen *screen) :
 
     set_position(nanogui::Vector2i(15,15));
     set_layout(new nanogui::GroupLayout());
-    set_fixed_size(nanogui::Vector2i(864,490));
+    set_size(nanogui::Vector2i(866, 528));
 
     video_widget = new nanogui::ImageView(this);
+    video_widget->set_size(nanogui::Vector2i(856,480));
 
     perform_layout(screen->nvg_context());
 }
@@ -47,5 +48,7 @@ void VideoFeedViewer::update_frame(int stream, net::Frame& frame) {
 
     next_frame->upload((uint8_t *) next_frame_buffer);
     video_widget->set_image(next_frame);
+    video_widget->center();
+    video_widget->set_scale((float)856/CAMERA_WIDTH);
 }
 

--- a/src/basestation/modules/video_feed_viewer.hpp
+++ b/src/basestation/modules/video_feed_viewer.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <nanogui/nanogui.h>
+#include <turbojpeg.h>
+#include <GL/gl.h>
+#include "video_decoder/decoder.hpp"
+#include <iostream>
+
+class VideoFeedViewer : public nanogui::Window {
+public:
+    VideoFeedViewer(nanogui::Screen* screen);
+    static void update_frame_STATIC(int stream, net::Frame& frame);
+    void update_frame(int stream, net::Frame& frame);
+protected:
+    nanogui::ImageView* video_widget;
+private:
+    Decoder decoder;
+};

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -16,7 +16,7 @@ void net::MessageSender::send_message(msg::Message& message) {
 	bool success = false;
 
 	// Ensure size isn't larger than supported by the header
-	if (message.data_p->ByteSizeLong() <= msg::Header::MAX_MSG_SIZE) {
+	if (message.data_p->ByteSize() <= msg::Header::MAX_MSG_SIZE) {
 		uint8_t* block = buf.create_block(message.data_p->GetCachedSize() + msg::Header::HDR_SIZE);
 		
 		success = message.data_p->SerializeWithCachedSizesToArray(&block[msg::Header::HDR_SIZE]);

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -9,7 +9,7 @@
 #include <google/protobuf/message.h>
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
-#include <messages.hpp>
+#include "messages.hpp"
 
 namespace net {
 

--- a/src/network/stream.cpp
+++ b/src/network/stream.cpp
@@ -37,8 +37,8 @@ void net::StreamSender::send_frame(int stream, uint8_t* data, std::size_t len) {
 
 	hdr.write(header_buffer);
 
+
 	while (len > 0) {
-		
 		std::size_t n_sent = (len > max_section_size) ? max_section_size : len;
 		hdr.write_new_section(header_buffer);
 

--- a/src/video/camera.hpp
+++ b/src/video/camera.hpp
@@ -6,7 +6,7 @@
 
 #include <linux/videodev2.h>
 
-#include <roversystem/util.hpp>
+#include "roversystem_utils/include/roversystem/util.hpp"
 
 /*
     This library uses the Video4Linux kernel library to grab camera frames.

--- a/src/video/session.hpp
+++ b/src/video/session.hpp
@@ -1,10 +1,10 @@
 #ifndef SESSION
 #define SESSION
 
-#include <roversystem/logger.hpp>
-#include <roversystem/util.hpp>
-#include <network.hpp>
-#include <stream.hpp>
+#include "roversystem_utils/include/roversystem/logger.hpp"
+#include "roversystem_utils/include/roversystem/util.hpp"
+#include "../network/network.hpp"
+#include "../network/stream.hpp"
 
 #include "camera.hpp"
 


### PR DESCRIPTION
**How to display the video feed**
- After running the video computer, run the basestation and press C to open the feed window

**Some shortcomings of this branch**
- Values for setting up the network receiver are done manually.
- Had to do a workaround for the StreamReceiver callback to update frames in the feed window.
- Window size values are hard-coded.

