### PR TITLE
Create status bar for base station

### DIFF
--- a/src/basestation/CMakeLists.txt
+++ b/src/basestation/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MODULE_HDR
 	modules/console.hpp
 	modules/network_settings.cpp
 	modules/drive_stats.hpp
+	modules/statusbar.hpp
 	modules/input_config/controller_config.hpp
 	modules/input_config/controller_calibration_popup.hpp
 	modules/input_config/controller_binding_popup.hpp
@@ -10,6 +11,7 @@ set(MODULE_SRC
 	modules/console.cpp
 	modules/network_settings.cpp
 	modules/drive_stats.cpp
+	modules/statusbar.cpp
 	modules/input_config/controller_config.cpp
 	modules/input_config/controller_calibration_popup.cpp
 	modules/input_config/controller_binding_popup.cpp
@@ -19,6 +21,8 @@ set(WIDGET_HDR
 	widgets/window.hpp
 	widgets/textarea.hpp
 	widgets/functionbox.hpp
+	widgets/tray.hpp
+	widgets/toolbar.hpp
 	widgets/layouts/simple_row.hpp
 	widgets/layouts/simple_column.hpp
 )
@@ -26,6 +30,8 @@ set(WIDGET_SRC
 	widgets/window.cpp
 	widgets/textarea.cpp
 	widgets/functionbox.cpp
+	widgets/tray.cpp
+	widgets/toolbar.cpp
 	widgets/layouts/simple_row.cpp
 	widgets/layouts/simple_column.cpp
 )

--- a/src/basestation/basestation.cpp
+++ b/src/basestation/basestation.cpp
@@ -101,6 +101,7 @@ void Basestation::read_settings(const boost::property_tree::ptree& settings_tree
 
 			try {
 				m_subsystem_feed.set_listen_endpoint(feed_ep);
+				m_subsystem_feed.set_multicast(use_multicast);
 
 				if (enable && (ip || !use_multicast) && port && !m_subsystem_feed.opened()) {
 					m_subsystem_feed.open();

--- a/src/basestation/basestation_screen.cpp
+++ b/src/basestation/basestation_screen.cpp
@@ -2,6 +2,7 @@
 #include <basestation.hpp>
 
 #include <modules/console.hpp>
+#include <modules/statusbar.hpp>
 
 ScreenPositioning::ScreenPositioning(const nanogui::Vector2i& size, const nanogui::Vector2i& window_pos, int monitor, bool use_fullscreen) :
 	size(size),
@@ -14,6 +15,14 @@ ScreenPositioning::ScreenPositioning(const nanogui::Vector2i& size, const nanogu
 BasestationScreen::BasestationScreen(const ScreenPositioning& pos)
 	: nanogui::Screen(pos.size, "Base Station - Binghamton University Rover Team", true, pos.use_fullscreen),
 	position(pos) {
+
+	// Theme Constants
+	// Future: When fancy dynamic themes are supported, remove this section
+	m_theme->m_window_drop_shadow_size = 0;
+	m_theme->m_window_fill_focused.a() = 1.0F;
+	m_theme->m_window_fill_unfocused.a() = 1.0F;
+
+	new gui::Statusbar(this);
 
 	perform_layout();
 	draw_all();
@@ -131,6 +140,8 @@ bool BasestationScreen::resize_event(const nanogui::Vector2i& size) {
 	if (!m_fullscreen) {
 		position.size = m_size;
 	}
+
+	perform_layout();
 
 	return ret;
 }

--- a/src/basestation/modules/statusbar.cpp
+++ b/src/basestation/modules/statusbar.cpp
@@ -4,6 +4,7 @@
 #include <nanogui/toolbutton.h>
 #include <nanogui/screen.h>
 
+#include <basestation.hpp>
 #include <modules/console.hpp>
 #include <modules/network_settings.hpp>
 
@@ -16,13 +17,41 @@ gui::Statusbar::Statusbar(nanogui::Widget* parent) : gui::Toolbar(parent) {
 		});
 	}
 	{
-		auto network_button = new nanogui::ToolButton(right_tray(), FA_NETWORK_WIRED);
+		network_button = new nanogui::ToolButton(right_tray(), FA_NETWORK_WIRED);
 		network_button->set_flags(nanogui::Button::NormalButton);
 		network_button->set_callback([this] {
 			auto wnd = new gui::NetworkSettings(screen());
 			place_in_right_corner(wnd);
 		});
 	}
+}
+
+void gui::Statusbar::draw(NVGcontext* ctx) {
+	Basestation& bs(Basestation::get());
+	
+	// Estimate signal strength using the average activity interval
+	// Set the symbol color based on strength
+
+	auto last_msg_time = bs.subsystem_feed().latest_activity_time();
+	auto now = std::chrono::system_clock::now();
+
+	if (!bs.subsystem_feed().opened()) {
+		network_button->set_icon(FA_NETWORK_WIRED);
+	} else {
+		if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_msg_time).count() > 800) {
+			// Blink when connection is lost
+			auto now_steady = std::chrono::steady_clock::now();
+			if (now_steady >= next_net_animation) {
+				next_net_animation = now_steady + std::chrono::milliseconds(500);
+
+				network_button->set_icon(network_button->icon() == 0 ? FA_WIFI : 0);
+			}
+		} else {
+			network_button->set_icon(FA_WIFI);
+		}
+	}
+
+	gui::Toolbar::draw(ctx);
 }
 
 void gui::Statusbar::place_in_right_corner(nanogui::Window* wnd) {

--- a/src/basestation/modules/statusbar.cpp
+++ b/src/basestation/modules/statusbar.cpp
@@ -1,0 +1,31 @@
+#include <modules/statusbar.hpp>
+
+#include <nanogui/icons.h>
+#include <nanogui/toolbutton.h>
+#include <nanogui/screen.h>
+
+#include <modules/console.hpp>
+#include <modules/network_settings.hpp>
+
+gui::Statusbar::Statusbar(nanogui::Widget* parent) : gui::Toolbar(parent) {
+	{
+		auto term_button = new nanogui::ToolButton(right_tray(), FA_TERMINAL);
+		term_button->set_flags(nanogui::Button::NormalButton);
+		term_button->set_callback([this] {
+			new Console(screen());
+		});
+	}
+	{
+		auto network_button = new nanogui::ToolButton(right_tray(), FA_NETWORK_WIRED);
+		network_button->set_flags(nanogui::Button::NormalButton);
+		network_button->set_callback([this] {
+			auto wnd = new gui::NetworkSettings(screen());
+			place_in_right_corner(wnd);
+		});
+	}
+}
+
+void gui::Statusbar::place_in_right_corner(nanogui::Window* wnd) {
+	auto scr = wnd->screen();
+	wnd->set_position(nanogui::Vector2i(scr->width() - wnd->width(), scr->height() - wnd->height() - height()));
+}

--- a/src/basestation/modules/statusbar.hpp
+++ b/src/basestation/modules/statusbar.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <widgets/toolbar.hpp>
+#include <chrono>
 
 namespace gui {
 
@@ -16,8 +17,14 @@ namespace gui {
 class Statusbar : public gui::Toolbar {
 	public:
 		Statusbar(nanogui::Widget* parent);
+
+		virtual void draw(NVGcontext* ctx) override;
+
 	private:
 		void place_in_right_corner(nanogui::Window* wnd);
+
+		nanogui::Button* network_button;
+		std::chrono::steady_clock::time_point next_net_animation;
 };
 
 }

--- a/src/basestation/modules/statusbar.hpp
+++ b/src/basestation/modules/statusbar.hpp
@@ -1,0 +1,23 @@
+/*
+	Collection of classes used for the status toolbar utility, including
+	1. The toolbar itself
+	2. Working on it...
+*/
+
+#pragma once
+
+#include <widgets/toolbar.hpp>
+
+namespace gui {
+
+/*
+	The main toolbar for base station status shown across the bottom of every screen
+*/
+class Statusbar : public gui::Toolbar {
+	public:
+		Statusbar(nanogui::Widget* parent);
+	private:
+		void place_in_right_corner(nanogui::Window* wnd);
+};
+
+}

--- a/src/basestation/widgets/layouts/simple_row.cpp
+++ b/src/basestation/widgets/layouts/simple_row.cpp
@@ -109,6 +109,7 @@ void gui::SimpleRowLayout::perform_layout(NVGcontext* ctx, nanogui::Widget* cont
 		}
 		new_pos.y() += y_pos;
 		w->set_position(new_pos);
+		w->perform_layout(ctx);
 
 	}
 	

--- a/src/basestation/widgets/toolbar.cpp
+++ b/src/basestation/widgets/toolbar.cpp
@@ -1,0 +1,52 @@
+#include <widgets/toolbar.hpp>
+
+#include <widgets/layouts/simple_row.hpp>
+#include <nanogui/opengl.h>
+#include <nanogui/screen.h>
+
+gui::Toolbar::Toolbar(nanogui::Widget* parent, const nanogui::Color& bg_color) :
+	nanogui::Widget(parent),
+	m_background_color(bg_color) {
+
+	//set_layout(new nanogui::BoxLayout(nanogui::Orientation::Horizontal));
+	set_layout(new gui::SimpleRowLayout(6, 0));
+
+	// Create a left, right, and center tray with blank widgets to align them
+	bool first = true;
+	for (auto& tray : trays) {
+		if (first)
+			first = false;
+		else
+			new nanogui::Widget(this);
+
+		tray = new gui::Tray(this);
+	}
+
+}
+
+void gui::Toolbar::draw(NVGcontext* ctx) {
+	nvgBeginPath(ctx);
+	nvgRect(ctx, m_pos.x(), m_pos.y(), m_pos.x() + m_size.x(), m_pos.y() + m_size.y());
+	nvgFillColor(ctx, m_background_color);
+	nvgFill(ctx);
+	nvgClosePath(ctx);
+
+	nanogui::Widget::draw(ctx);
+}
+
+nanogui::Vector2i gui::Toolbar::preferred_size(NVGcontext* ctx) const {
+	return nanogui::Vector2i(m_parent->width(), nanogui::Widget::preferred_size(ctx).y());
+}
+
+void gui::Toolbar::perform_layout(NVGcontext* ctx) {
+	for (auto tray : trays) {
+		tray->set_fixed_size(tray->preferred_size(ctx));
+	}
+	nanogui::Widget::perform_layout(ctx);
+
+	// Place at the bottom corner of the parent
+	set_position(nanogui::Vector2i(
+		m_parent->position().x(),
+		m_parent->position().y() + m_parent->size().y() - m_size.y()
+	));
+}

--- a/src/basestation/widgets/toolbar.hpp
+++ b/src/basestation/widgets/toolbar.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <nanogui/widget.h>
+#include <widgets/tray.hpp>
+#include <array>
+
+namespace gui {
+
+class Toolbar : public nanogui::Widget {
+	public:
+		Toolbar(nanogui::Widget* parent, const nanogui::Color& bg_color = nanogui::Color(0, 122, 204, 255));
+
+		const nanogui::Color& background_color() const { return m_background_color; }
+		void set_background_color(const nanogui::Color& c) { m_background_color = c; }
+		
+		gui::Tray* left_tray() { return trays[0]; }
+		gui::Tray* center_tray() { return trays[1]; }
+		gui::Tray* right_tray() { return trays[2]; }
+
+		virtual void draw(NVGcontext* ctx) override;
+		virtual void perform_layout(NVGcontext* ctx) override;
+		virtual nanogui::Vector2i preferred_size(NVGcontext* ctx) const override;
+
+	private:
+		nanogui::Color m_background_color;
+
+		std::array<gui::Tray*, 3> trays;
+};
+
+}

--- a/src/basestation/widgets/tray.cpp
+++ b/src/basestation/widgets/tray.cpp
@@ -1,0 +1,30 @@
+#include <widgets/tray.hpp>
+
+#include <widgets/layouts/simple_row.hpp>
+#include <nanogui/opengl.h>
+
+gui::Tray::Tray(nanogui::Widget* parent) :
+	nanogui::Widget(parent) {
+	
+	// Use a transparent style for buttons in the tray
+	m_theme = new nanogui::Theme(*m_theme);
+	m_theme->m_button_corner_radius = 0;
+
+	nanogui::Color full_transparency(0, 0, 0, 0);
+	nanogui::Color light_shading(1.0F, 1.0F, 1.0F, 0.2F);
+	nanogui::Color heavy_shading(1.0F, 1.0F, 1.0F, 0.4F);
+
+	m_theme->m_button_gradient_bot_unfocused = full_transparency;
+	m_theme->m_button_gradient_top_unfocused = full_transparency;
+
+	m_theme->m_button_gradient_bot_focused = light_shading;
+	m_theme->m_button_gradient_top_focused = light_shading;
+
+	m_theme->m_button_gradient_bot_pushed = heavy_shading;
+	m_theme->m_button_gradient_top_pushed = heavy_shading;
+
+	m_theme->m_border_light = full_transparency;
+	m_theme->m_border_dark = full_transparency;
+
+	set_layout(new gui::SimpleRowLayout(0, 4));
+}

--- a/src/basestation/widgets/tray.hpp
+++ b/src/basestation/widgets/tray.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <nanogui/widget.h>
+
+namespace gui {
+
+// Well, this isn't much more than an alias for a widget
+// It comes with a modern theme for placing buttons in the tray
+class Tray : public nanogui::Widget {
+	public:
+		Tray(nanogui::Widget* parent);
+
+};
+
+}

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -191,8 +191,11 @@ void net::MessageReceiver::listen() {
 	socket.async_receive_from(boost::asio::buffer(recv_buffer), remote, [this](boost::system::error_code ec, std::size_t bytes_transferred) {
 		read_messages(recv_buffer.data(), bytes_transferred);
 
-		if (ec && ec != boost::asio::error::operation_aborted) {
-			error_emitter(ec);
+		if (ec) {
+			if (ec != boost::asio::error::operation_aborted)
+				error_emitter(ec);
+		} else {
+			last_activity = std::chrono::system_clock::now();
 		}
 
 		listen();

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <cstdint>
 #include <limits>
+#include <chrono>
 #include <google/protobuf/message.h>
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
@@ -85,7 +86,9 @@ class MessageReceiver : public msg::Receiver {
 		inline bool opened() const { return socket.is_open(); }
 		inline Destination& remote_sender() { return remote; }
 		inline event::Emitter<const boost::system::error_code&>& event_receive_error() { return error_emitter; }
+		inline std::chrono::system_clock::time_point latest_activity_time() const { return last_activity; }
 	private:
+		std::chrono::system_clock::time_point last_activity{};
 		boost::asio::ip::udp::socket socket;
 		Destination remote;
 		boost::asio::ip::udp::endpoint listen_ep;


### PR DESCRIPTION
(Barely) Closes #59

Each base station screen gets a toolbar on the bottom to display current status.
* widgets/toolbar: A generic widget with left-, center-, and right-aligned trays
  * Modeled after the VSCode  status bar (currently steals the exact color too)
* modules/statusbar:  A specific toolbar for base station status
  * Has tray buttons for network and terminal
    *  Network light flashes when the connection is lost
  * Needs more work to populate

This does not address the utility widgets mentioned in the issue. Those are not vital right now.