### PR TITLE
Refactor CAN

### DIFF
--- a/src/subsystem/can/commands.cpp
+++ b/src/subsystem/can/commands.cpp
@@ -135,7 +135,7 @@ void parse_gripper_information(GripperInformation& write_to, uint64_t p) {
     write_to.gyro_z = (float((0x0000000000FF0000l & p) >> 16)) / 10.0f;
 }
 
-void get_environmental_analysis_information(EAInformation& write_to, uint64_t p) {
+void parse_environmental_analysis_information(EAInformation& write_to, uint64_t p) {
     write_to.temp = (float((0xFF00000000000000l & p) >> 56)) / 10.0f;
     write_to.methane = (float((0x00FF000000000000l & p) >> 48)) / 10.0f;
     write_to.c02 = (float((0x0000FF0000000000l & p) >> 40)) / 10.0f;

--- a/src/subsystem/can/commands.cpp
+++ b/src/subsystem/can/commands.cpp
@@ -127,12 +127,12 @@ void parse_arm_information(ArmInformation& write_to, uint64_t p) {
 }
 
 void parse_gripper_information(GripperInformation& write_to, uint64_t p) {
-    ret.temp1 = (float((0xFF00000000000000l & p) >> 56)) / 10.0f;
-    ret.temp2 = (float((0x00FF000000000000l & p) >> 48)) / 10.0f;
-    ret.temp3 = (float((0x0000FF0000000000l & p) >> 40)) / 10.0f;
-    ret.gyro_x = (float((0x000000FF00000000l & p) >> 32)) / 10.0f;
-    ret.gyro_y = (float((0x00000000FF000000l & p) >> 24)) / 10.0f;
-    ret.gyro_z = (float((0x0000000000FF0000l & p) >> 16)) / 10.0f;
+    write_to.temp1 = (float((0xFF00000000000000l & p) >> 56)) / 10.0f;
+    write_to.temp2 = (float((0x00FF000000000000l & p) >> 48)) / 10.0f;
+    write_to.temp3 = (float((0x0000FF0000000000l & p) >> 40)) / 10.0f;
+    write_to.gyro_x = (float((0x000000FF00000000l & p) >> 32)) / 10.0f;
+    write_to.gyro_y = (float((0x00000000FF000000l & p) >> 24)) / 10.0f;
+    write_to.gyro_z = (float((0x0000000000FF0000l & p) >> 16)) / 10.0f;
 }
 
 void get_environmental_analysis_information(EAInformation& write_to, uint64_t p) {

--- a/src/subsystem/can/commands.hpp
+++ b/src/subsystem/can/commands.hpp
@@ -46,18 +46,12 @@ constexpr int can_id(Node device, Command command) {
 
 uint64_t canframe_get_u64(can_frame* frame);
 
-//Receive all the vital information from each specific teensy
-ControlInformation get_control_information();
 void parse_control_information(ControlInformation& write_to, uint64_t p1, uint64_t p2);
 void parse_control_p1(ControlInformation& write_to, uint64_t p1);
 void parse_control_p2(ControlInformation& write_to, uint64_t p2);
 void parse_arm_information(ArmInformation& write_to, uint64_t p);
 void parse_gripper_information(GripperInformation& write_to, uint64_t p);
 void parse_environmental_analysis_information(EAInformation& write_to, uint64_t p);
-
-ArmInformation get_arm_information();
-GripperInformation get_gripper_information();
-EAInformation get_environmental_analysis_information();
 
 #ifdef ONBOARD_CAN_BUS
 //Create a can frame

--- a/src/subsystem/can/commands.hpp
+++ b/src/subsystem/can/commands.hpp
@@ -26,9 +26,6 @@ extern "C" {
 
 #include "constants.hpp"
 
-//Max time allowed for reading (in seconds)
-constexpr double MAX_READ_TIME = 0.6;
-
 //Overloads for can_send
 int can_send(Node device, Command command, unsigned int data);
 int can_send(Node device, Command command, int data);
@@ -41,9 +38,6 @@ int can_send(Node device, Command command, int num_bytes, unsigned int data);
 int can_request(Node device, Command command, float f);
 
 //Request to read a CAN message
-float can_read_float(Node device, Command command);
-int can_read_int(Node device, Command command);
-long long can_read_long(Node device, Command command);
 void can_read_all(const std::function<void(can_frame*)>& read_callback);
 
 constexpr int can_id(Node device, Command command) {
@@ -52,18 +46,14 @@ constexpr int can_id(Node device, Command command) {
 
 uint64_t canframe_get_u64(can_frame* frame);
 
-//Recieve a CAN message
-unsigned int can_receive(Node device, Command command);
-long long can_receive_long(Node device, Command command);
-
-//Recieve a CAN frame and check it's ID
-bool can_check_hearbeat(Node device);
-
 //Receive all the vital information from each specific teensy
 ControlInformation get_control_information();
 void parse_control_information(ControlInformation& write_to, uint64_t p1, uint64_t p2);
 void parse_control_p1(ControlInformation& write_to, uint64_t p1);
 void parse_control_p2(ControlInformation& write_to, uint64_t p2);
+void parse_arm_information(ArmInformation& write_to, uint64_t p);
+void parse_gripper_information(GripperInformation& write_to, uint64_t p);
+void get_environmental_analysis_information(EAInformation& write_to, uint64_t p);
 
 ArmInformation get_arm_information();
 GripperInformation get_gripper_information();

--- a/src/subsystem/can/commands.hpp
+++ b/src/subsystem/can/commands.hpp
@@ -53,7 +53,7 @@ void parse_control_p1(ControlInformation& write_to, uint64_t p1);
 void parse_control_p2(ControlInformation& write_to, uint64_t p2);
 void parse_arm_information(ArmInformation& write_to, uint64_t p);
 void parse_gripper_information(GripperInformation& write_to, uint64_t p);
-void get_environmental_analysis_information(EAInformation& write_to, uint64_t p);
+void parse_environmental_analysis_information(EAInformation& write_to, uint64_t p);
 
 ArmInformation get_arm_information();
 GripperInformation get_gripper_information();

--- a/src/subsystem/subsystem.cpp
+++ b/src/subsystem/subsystem.cpp
@@ -115,9 +115,6 @@ int main() {
 		panic_shutdown();
 	});
 	
-	// Open can socket
-	can_open_socket();
-
 	// Open the CAN Socket
 	if (!can_open_socket()) {
 		std::cout << "Warning: Unable to open CAN socket\n";


### PR DESCRIPTION
Removed unnecessary CAN methods and variables.

I left can_read_all() in the subsystem, this could be changed in the future if needed.

Closes #66 